### PR TITLE
From https://github.com/lobin-z0x50/sass-rails/commit/a7b666cd4cc6755…

### DIFF
--- a/lib/sass/rails/railtie.rb
+++ b/lib/sass/rails/railtie.rb
@@ -77,7 +77,7 @@ module Sass::Rails
         end
       end
 
-      Sass.logger = app.config.sass.logger
+      Sass.logger = app.config.sass[:logger]
     end
 
     initializer :setup_compression, group: :all do |app|


### PR DESCRIPTION
Bug? NoMethodError: undefined method `capture' in rule_node.rb:142
https://github.com/sass/sass/issues/2499

変更の元ネタ
https://github.com/lobin-z0x50/sass-rails/commit/a7b666cd4cc6755a2e33bb9c43a3b1b81e3a4ebe